### PR TITLE
fix .idea folders exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ Mkfile.old
 dkms.conf
 
 # CLion project folders
-*/.idea/*
+**/.idea/


### PR DESCRIPTION
Replaced */.idea/* with **/.idea/ to ignore all .idea folders however deep they are in the arborescence